### PR TITLE
Fix deserialize

### DIFF
--- a/joueur/client.js
+++ b/joueur/client.js
@@ -83,7 +83,7 @@ var Client = Class({
         });
 
         var ranData = this.waitForEvent("ran");
-        return Serializer.deserialize(ranData);
+        return Serializer.deserialize(ranData, this.game);
     },
 
     waitForEvent: function(event) {

--- a/joueur/serializer.js
+++ b/joueur/serializer.js
@@ -42,28 +42,27 @@ Serializer = {
     },
 
     deserialize: function(data, game) {
-        if(Serializer.isObject(data)) {
-            var result = data.isArray ? [] : {};
-
-            for(var key in data) {
-                var value = data[key];
-                if(typeof(value) == "object") {
-                    if(Serializer.isGameObjectReference(value)) { // it's a tracked game object
-                        result[key] = game.getGameObject(value.id);
-                    }
-                    else {
-                        result[key] = Serializer.deserialize(value);
-                    }
-                }
-                else {
-                    result[key] = value;
-                }
-            }
-
-            return result;
+        if(!Serializer.isObject(data)) {
+            return data;
+        }
+        
+        if(Serializer.isGameObjectReference(data)) { // it's a tracked game object
+            return game.getGameObject(data.id);
         }
 
-        return data;
+        var result = data.isArray ? [] : {};
+
+        for(var key in data) {
+            var value = data[key];
+            if(typeof(value) == "object") {
+                result[key] = Serializer.deserialize(value);
+            }
+            else {
+                result[key] = value;
+            }
+        }
+
+        return result;
     },
 };
 


### PR DESCRIPTION
Deserialize was broken for creating new units. Two changes were required to fix this bug. The call site of deserialize in the client needed to pass in the game object and the deserialize implementation needed to change in serializer (it now reflects other client implementations).